### PR TITLE
Remove Discourse comments for now

### DIFF
--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -17,33 +17,6 @@
       <p>{{ partial "translation-disclaimer" . }}</p>
 
       {{ .Content }}
-
-      {{ if eq .Language.Lang "en" }}
-          <h2 id="comments">Comments</h2>
-          <div id='discourse-comments'></div>
-          <script type="text/javascript">
-            // posts before 2020-03-01 (unix 1583020800) used ipfs.io/blog
-            DiscourseEmbed = { discourseUrl: 'https://discuss.ipfs.io/',
-              {{ if lt .Date.Unix 1583020800 }}
-                discourseEmbedUrl: 'https://{{ path.Join "ipfs.io/blog" .URL }}'
-              {{ else }}
-                discourseEmbedUrl: 'https://{{ path.Join "blog.ipfs.io" .URL }}'
-              {{ end }}
-            };
-              if (window.location.hostname === 'blog.ipfs.io') {
-                (function() {
-                  var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
-                  d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
-                  (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
-                })();
-              } else {
-                 // hide comment section when loaded from hostnames
-                 // other than the one whitelisted at discuss.ipfs.io
-                 document.getElementById('comments').style.display = 'none';
-                 document.getElementById('discourse-comments').style.display = 'none';
-              }
-          </script>
-      {{ end }}
     </div>
   </div> <!-- container -->
 


### PR DESCRIPTION
Because of various URL issues, each time a blog post is published Discourse gets poked about a couple of old IPFS camp posts, and then all people who subscribe to email notifications of the forums are notified by email about those old posts.

Separately, we just don't get a lot of comments in the Discourse threads for blog posts - maybe a couple per month: https://discuss.ipfs.io/c/news/blog-entries/20

I propose we remove this integration for now.